### PR TITLE
build: Rework kconfig files to easily add new boards and architectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,7 @@ bin
 
 .config.mk
 .config
-.config.old
+*.old
 src/common/config.h
 
 # python

--- a/Kconfig
+++ b/Kconfig
@@ -1,15 +1,7 @@
-menu "Target option"
-    config TARGET_BOARD
-        string
-        default "pico"
-        prompt "Target board name"
+mainmenu "Munix Configuration"
 
-    config TARGET_ARCH
-        string
-        default "m0plus"
-        prompt "Target architecture name"
-
-endmenu
+source "src/arch/Kconfig"
+source "src/board/Kconfig"
 
 menu "IPC option"
     config IPC_CHANNEL_COUNT

--- a/src/arch/Kconfig
+++ b/src/arch/Kconfig
@@ -1,0 +1,10 @@
+choice
+    prompt "Architecture"
+    default ARM
+
+config ARM
+    bool "ARM architecture"
+
+endchoice
+
+source "src/arch/arm/Kconfig"

--- a/src/arch/arm/Kconfig
+++ b/src/arch/arm/Kconfig
@@ -1,0 +1,23 @@
+menu "ARM architecture"
+    depends on ARM
+
+config TARGET_ARCH
+    string
+    default "arm"
+
+choice
+    prompt "Target select"
+    default ARCH_RP2040
+
+config ARCH_RP2040
+    bool "RP2040"
+
+config ARCH_BCM283X
+    bool "bcm283x"
+
+endchoice
+
+endmenu
+
+source "src/arch/arm/rp2040/Kconfig"
+source "src/arch/arm/bcm283x/Kconfig"

--- a/src/arch/arm/bcm283x/Kconfig
+++ b/src/arch/arm/bcm283x/Kconfig
@@ -1,0 +1,7 @@
+if ARCH_BCM283X
+
+config TARGET_SOC
+    string
+    default "bcm283x"
+
+endif

--- a/src/arch/arm/rp2040/Kconfig
+++ b/src/arch/arm/rp2040/Kconfig
@@ -1,0 +1,7 @@
+if ARCH_RP2040
+
+config TARGET_SOC
+    string
+    default "rp2040"
+
+endif

--- a/src/board/Kconfig
+++ b/src/board/Kconfig
@@ -1,0 +1,8 @@
+choice
+    prompt "Board"
+    default BOARD_PICO
+
+source "src/board/pico/Kconfig"
+source "src/board/rpizero/Kconfig"
+
+endchoice

--- a/src/board/pico/Kconfig
+++ b/src/board/pico/Kconfig
@@ -1,0 +1,11 @@
+config BOARD_PICO
+    bool "Support Raspberry PI pico"
+    depends on ARCH_RP2040
+
+if BOARD_PICO
+
+    config TARGET_BOARD
+        string
+        default "pico"
+
+endif

--- a/src/board/rpizero/Kconfig
+++ b/src/board/rpizero/Kconfig
@@ -1,0 +1,11 @@
+config BOARD_RPIZERO
+    bool "Support Raspberry PI ZERO"
+    depends on ARCH_BCM283X
+
+if BOARD_RPIZERO
+
+    config TARGET_BOARD
+        string
+        default "rpizero"
+
+endif


### PR DESCRIPTION
Add RPI Zero as example